### PR TITLE
Change threading implementation to use `QRunnable` and `QThreadPool`. Re-factored signals in `GEMspaWorker`.

### DIFF
--- a/src/napari_gemspa/_gemspa_file_import_widget.py
+++ b/src/napari_gemspa/_gemspa_file_import_widget.py
@@ -4,6 +4,7 @@ import os
 
 import napari
 import nd2
+import mrc
 import numpy as np
 import pandas as pd
 from gemspa_spt import ParticleTracks
@@ -203,7 +204,7 @@ class GEMspaFileImportWidget(QWidget):
 
     def _load_image_file(self):
         filename, _ = QFileDialog.getOpenFileName(
-            self, "time-lapse movies (*.tif *.tiff *.nd2)"
+            self, "time-lapse movies (*.tif *.tiff *.nd2 *.dv)"
         )
         if filename:
             ext = os.path.splitext(filename)[1]
@@ -213,6 +214,10 @@ class GEMspaFileImportWidget(QWidget):
                 f.close()
             elif ext == ".tif" or ext == ".tiff":
                 images = io.imread(filename)
+            elif ext == ".dv":
+                f = mrc.DVFile(filename)
+                images = f.asarray()
+                f.close()
             else:
                 raise ValueError(f"Unrecognized file extension for image file {ext}")
 

--- a/src/napari_gemspa/_gemspa_file_import_widget.py
+++ b/src/napari_gemspa/_gemspa_file_import_widget.py
@@ -4,7 +4,6 @@ import os
 
 import napari
 import nd2
-import mrc
 import numpy as np
 import pandas as pd
 from gemspa_spt import ParticleTracks
@@ -214,10 +213,6 @@ class GEMspaFileImportWidget(QWidget):
                 f.close()
             elif ext == ".tif" or ext == ".tiff":
                 images = io.imread(filename)
-            elif ext == ".dv":
-                f = mrc.DVFile(filename)
-                images = f.asarray()
-                f.close()
             else:
                 raise ValueError(f"Unrecognized file extension for image file {ext}")
 


### PR DESCRIPTION
Previously it was done using `QThread` in the class `GEMspaWidget`. A worker instance, specific to a particular task (subclassed from `GEMspaWorker`), was then assigned to the thread within another sub-classed widget (derived from `GEMspaWidget`). The definition of the method that executes the specific task is defined in the generic `GEMspaWidget.start_task()`. This required `super().start_task()` calls from the task-specific (e.g. `GEMspaLocateWidget`) object derived that was tricky to debug.

In this pull request, I've removed the method definition within `GEMspaWidget.start_task()` so that each sub-class needs to implement its own execution logic. This requires that each task-specific widget to have an overloaded implementation for `start_task()` method. Although it becomes a bit more repetitive, this avoids doing calls to `super().start_task()`.

I've also re-factored the signals in `GEMspaWorker` into its own class, `GEMspaSignals`, so that a worker instance have all of its signals accessible from the attribute `GEMspaWorker.signals` to make it a bit more clear when passing data between widgets or functions from between threaded executions.
